### PR TITLE
Updated ViteConfig

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,9 +12,6 @@ export default defineConfig({
   server: {
     host: true,
     port: 3000,
-    hmr: {
-      overlay: true,
-    },
   },
   plugins: [
     remix({

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,13 @@ declare module "@remix-run/node" {
 }
 
 export default defineConfig({
+  server: {
+    host: true,
+    port: 3000,
+    hmr: {
+      overlay: true,
+    },
+  },
   plugins: [
     remix({
       future: {


### PR DESCRIPTION
Added a `server` configuration specifying `host: true` and `port: 3000` to allow external access and set the development server to run on port 3000.